### PR TITLE
chore: add Laravel 12 support while maintaining Laravel 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": "^8.3.0",
+        "php": "^8.2.0",
         "ext-zlib": "*",
-        "illuminate/http": "^11.0",
-        "illuminate/support": "^11.0"
+        "illuminate/http": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18.1",
-        "orchestra/testbench": "^9.8",
+        "orchestra/testbench": "^9.8|^10.0",
         "pestphp/pest": "^3.7",
         "pestphp/pest-plugin-type-coverage": "^3.1",
         "phpstan/phpstan": "^1.12.7",


### PR DESCRIPTION
## 🎯 What This PR Does

Adds support for Laravel 12, PHP 8.2 onward, while maintaining full backwards compatibility with Laravel 11.

## 📋 Changes Made

- ✅ Updated `illuminate/http` constraint to `^11.0|^12.0`
- ✅ Updated `illuminate/support` constraint to `^11.0|^12.0` 
- ✅ Updated `orchestra/testbench` constraint to `^9.8|^10.0`
- ✅ Added PHP 8.2 support (`^8.2.0|^8.3.0`)
- ✅ Maintains backwards compatibility with Laravel 11
- ✅ No breaking changes

## 🧪 Testing
- [x] All existing tests pass

## 📚 Additional Context

This change allows users to:
- Use the package with PHP 8.2, 8.3 or 8.4
- Continue using the package with Laravel 11 projects
- Upgrade to Laravel 12 when ready without being blocked by this dependency
- Migrate between Laravel/PHP versions at their own pace

## 🔄 Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (dependency updates, tooling changes, maintenance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update